### PR TITLE
fix path for docker volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - .env
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
-      - .:/ban-berlinarchnet
+      - .:/opt/ban-berlinarchnet
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
Fixed wrong path for docker volume:
`/opt/ban-berlinarchnet`