### PR TITLE
add rails default vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 
 # Ignore vendor folder
 /vendor/*
+!/vendor/.keep
 
 /public/assets
 .byebug_history


### PR DESCRIPTION
Adds back Rails defaults vendor folder, but ignores its content.