### PR TITLE
organize gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,17 +84,3 @@ group :test do
   gem 'shoulda-matchers', '4.0.0.rc1'
   gem 'rspec-html-matchers'
 end
-
-
-# Remove
-#-------------------------------------------------------------------------------
-# gem 'image_processing', '~> 1.2'
-# gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-# gem 'listen', '~> 3.2'
-# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-# gem "net-http"
-# gem 'capybara', '~> 3.33'
-# gem 'selenium-webdriver', '~> 3.142', '>= 3.142.7'
-# gem 'webdriver', '~> 0.17.0'
-# gem 'launchy', '~> 2.5'
-# git_source(:github) { |repo| "https://github.com/#{repo}.git" }

--- a/Gemfile
+++ b/Gemfile
@@ -1,103 +1,100 @@
-source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+# frozen_string_literal: true
 
+source 'https://rubygems.org'
 ruby '3.2.2'
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 7.0', '>= 7.0.5'
-# Use postgresql as the database for Active Record
-gem 'pg', '>= 0.18', '< 2.0'
-# Use Puma as the app server
+# Rails
+#-------------------------------------------------------------------------------
 gem 'puma', '~> 4.1'
-# Sprockets is now an optional dependency
-gem 'sprockets-rails', '~> 3.4', '>= 3.4.2'
-# Use SCSS for stylesheets
-gem 'sassc-rails', '~> 2.1', '>= 2.1.2'
-# Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker', '~> 5.4', '>= 5.4.4'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.7'
-# Use Redis adapter to run Action Cable in production
-gem 'redis', '~> 4.0'
-# Nokogiri gem
-gem 'nokogiri', '~> 1.10', '>= 1.10.10'
-# Watir gem
-gem 'watir', '~> 6.16', '>= 6.16.5'
-# Whenever gem
-gem 'whenever', '~> 0.9.4', require: false
-# PG Search
+gem 'rails', '~> 7.0', '>= 7.0.5'
+
+# Database
+#-------------------------------------------------------------------------------
+gem 'pg', '>= 0.18', '< 2.0'
 gem 'pg_search', '~> 2.3', '>= 2.3.5'
 
-# Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-# Act-as-taggable-on gem
-# gem 'acts-as-taggable-on', '~> 6.0'
+# Redis
+#-------------------------------------------------------------------------------
+gem 'redis', '~> 4.0' # Use Redis adapter to run Action Cable in production
 
-#Act-as-votable gem
-
-# Use Active Storage variant
-gem 'image_processing', '~> 1.2'
-
-# Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.2', require: false
-
-# Devise gem
-gem 'devise', '~> 4.7', '>= 4.7.3'
-
-# Pundit gem
-gem 'pundit', '~> 2.1'
-
-# Act as taggable
-gem 'acts-as-taggable-on', '~> 9.0', '>= 9.0.1'
-
-# Cloudinary gem
-gem 'cloudinary', '~> 1.18', '>= 1.18.1'
-
-# Rails Admin gem
-gem 'rails_admin', '~> 3.1', '>= 3.1.2'
-
-# Faker gem
-gem 'faker', '~> 2.14'
-
-gem 'dotenv-rails', groups: [:development, :test]
-gem 'autoprefixer-rails', '~> 10.0', '>= 10.0.2.0'
-gem 'font-awesome-sass'
+# Views
+#-------------------------------------------------------------------------------
 gem 'simple_form'
 
+# Asset Pipeline
+#-------------------------------------------------------------------------------
+gem 'sassc-rails', '~> 2.1', '>= 2.1.2' # Use SCSS for stylesheets
+gem 'sprockets-rails', '~> 3.4', '>= 3.4.2' # Sprockets is now an optional dependency
+gem 'webpacker', '~> 5.4', '>= 5.4.4' # Transpile app-like JavaScript
+gem 'turbolinks', '~> 5' # Turbolinks makes navigating your web application faster
+gem 'turbolinks_render'
+gem 'autoprefixer-rails', '~> 10.0', '>= 10.0.2.0' # Parse CSS and add vendor prefixes to CSS rules
+gem 'font-awesome-sass' # Sass-powered version of Font Awesome for Ruby projects with specific support for Ruby on Rails and Sprockets
+
+# Authentication & Authorisation
+#-------------------------------------------------------------------------------
+gem 'devise', '~> 4.7', '>= 4.7.3'
+gem 'pundit', '~> 2.1'
+
+# Monitoring/Alerting/Comparing
+#-------------------------------------------------------------------------------
+gem 'rails_admin', '~> 3.1', '>= 3.1.2'
+
+# Background processing
+#-------------------------------------------------------------------------------
+gem 'whenever', '~> 0.9.4', require: false
+
+# API
+#-------------------------------------------------------------------------------
+gem 'jbuilder', '~> 2.7' # Build JSON APIs with ease.
+
+# Geocoding
+#-------------------------------------------------------------------------------
+gem 'geocoder'
+
+# Scrapping
+#-------------------------------------------------------------------------------
+gem 'nokogiri', '~> 1.10', '>= 1.10.10'
+gem 'watir', '~> 6.16', '>= 6.16.5'
+
+# External Services
+#-------------------------------------------------------------------------------
+gem 'cloudinary', '~> 1.18', '>= 1.18.1'
+
+# Miscellaneous gems
+#-------------------------------------------------------------------------------
+gem 'faker', '~> 2.14'
+gem 'acts-as-taggable-on', '~> 9.0', '>= 9.0.1'
+gem 'pry-rails'
+
+
 group :development, :test do
+  gem 'dotenv-rails'
   gem 'pry-byebug'
-  gem 'pry-rails'
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
+  gem 'bootsnap', '>= 1.4.2', require: false # Reduces boot times through caching; required in config/boot.rb
+end
+
+group :development do
+  gem 'web-console', '>= 3.3.0' # Access an interactive console on exception pages or by calling 'console' anywhere in the code
+end
+
+group :test do
   gem 'rails-controller-testing'
   gem 'shoulda-matchers', '4.0.0.rc1'
   gem 'rspec-html-matchers'
 end
 
-group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
-  gem 'listen', '~> 3.2'
-end
 
-group :test do
-  # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 3.33'
-  gem 'selenium-webdriver', '~> 3.142', '>= 3.142.7'
-  # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdriver', '~> 0.17.0'
-  gem 'launchy', '~> 2.5'
-end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-# Geocoder gemfile
-gem 'geocoder'
-gem 'turbolinks_render'
-
-# HTTP client api for Ruby.
-gem "net-http"
+# Remove
+#-------------------------------------------------------------------------------
+# gem 'image_processing', '~> 1.2'
+# gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+# gem 'listen', '~> 3.2'
+# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+# gem "net-http"
+# gem 'capybara', '~> 3.33'
+# gem 'selenium-webdriver', '~> 3.142', '>= 3.142.7'
+# gem 'webdriver', '~> 0.17.0'
+# gem 'launchy', '~> 2.5'
+# git_source(:github) { |repo| "https://github.com/#{repo}.git" }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,6 @@ GEM
       tzinfo (~> 2.0)
     acts-as-taggable-on (9.0.1)
       activerecord (>= 6.0, < 7.1)
-    addressable (2.8.4)
-      public_suffix (>= 2.0.2, < 6.0)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
     aws_cf_signer (0.1.3)
@@ -83,15 +81,6 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.39.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
     childprocess (3.0.0)
     chronic (0.10.2)
     cloudinary (1.25.0)
@@ -129,9 +118,6 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.0)
       concurrent-ruby (~> 1.0)
-    image_processing (1.12.2)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -147,11 +133,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    launchy (2.5.2)
-      addressable (~> 2.8)
-    listen (3.8.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -161,19 +142,15 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
-    matrix (0.4.2)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
-    mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
     minitest (5.18.0)
     msgpack (1.7.0)
     nested_form (0.3.2)
-    net-http (0.3.2)
-      uri
     net-imap (0.3.6)
       date
       net-protocol
@@ -201,7 +178,6 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (5.0.1)
     puma (4.3.12)
       nio4r (~> 2.0)
     pundit (2.3.0)
@@ -250,9 +226,6 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
-      ffi (~> 1.0)
     redis (4.8.1)
     regexp_parser (2.7.0)
     responders (3.1.0)
@@ -287,8 +260,6 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.12.0)
-    ruby-vips (2.1.4)
-      ffi (~> 1.12)
     rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -334,7 +305,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    uri (0.12.1)
     warden (1.2.9)
       rack (>= 2.0.9)
     watir (6.19.1)
@@ -345,7 +315,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdriver (0.17.0)
     webpacker (5.4.4)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -356,8 +325,6 @@ GEM
     websocket-extensions (0.1.5)
     whenever (0.9.7)
       chronic (>= 0.6.3)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -367,19 +334,13 @@ DEPENDENCIES
   acts-as-taggable-on (~> 9.0, >= 9.0.1)
   autoprefixer-rails (~> 10.0, >= 10.0.2.0)
   bootsnap (>= 1.4.2)
-  byebug
-  capybara (~> 3.33)
   cloudinary (~> 1.18, >= 1.18.1)
   devise (~> 4.7, >= 4.7.3)
   dotenv-rails
   faker (~> 2.14)
   font-awesome-sass
   geocoder
-  image_processing (~> 1.2)
   jbuilder (~> 2.7)
-  launchy (~> 2.5)
-  listen (~> 3.2)
-  net-http
   nokogiri (~> 1.10, >= 1.10.10)
   pg (>= 0.18, < 2.0)
   pg_search (~> 2.3, >= 2.3.5)
@@ -394,16 +355,13 @@ DEPENDENCIES
   rspec-html-matchers
   rspec-rails
   sassc-rails (~> 2.1, >= 2.1.2)
-  selenium-webdriver (~> 3.142, >= 3.142.7)
   shoulda-matchers (= 4.0.0.rc1)
   simple_form
   sprockets-rails (~> 3.4, >= 3.4.2)
   turbolinks (~> 5)
   turbolinks_render
-  tzinfo-data
   watir (~> 6.16, >= 6.16.5)
   web-console (>= 3.3.0)
-  webdriver (~> 0.17.0)
   webpacker (~> 5.4, >= 5.4.4)
   whenever (~> 0.9.4)
 
@@ -411,4 +369,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.14
+   2.4.21


### PR DESCRIPTION
Organize gems according to topics and remove unnecessary gems.

Following gems were removed:
```
# gem 'image_processing', '~> 1.2'
# gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
# gem 'listen', '~> 3.2'
# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
# gem "net-http"
# gem 'capybara', '~> 3.33'
# gem 'selenium-webdriver', '~> 3.142', '>= 3.142.7'
# gem 'webdriver', '~> 0.17.0'
# gem 'launchy', '~> 2.5'
# git_source(:github) { |repo| "https://github.com/#{repo}.git" }
```